### PR TITLE
Use `makesplits` instead of `makesplits_seed` in `scale_metric.m`

### DIFF
--- a/scale_metric.m
+++ b/scale_metric.m
@@ -34,8 +34,8 @@ for split = 1:cv_folds
 
 
     % First heuristically find a proper scale to avoid numeric problems
-    for ii = randperm(length(idx_val),500)
-        M = distance(A_SWCD*xtr{ii}, A_SWCD*xv{ii});
+    for ii = randperm(length(ytr),500)
+        M = distance(A_SWCD*xtr{ii}, A_SWCD*xv{mod(ii,length(idx_val))+1}));
         dis_max(ii) = max(max(M));
     end
     A_SWCD = A_SWCD/sqrt(mean(dis_max));

--- a/scale_metric.m
+++ b/scale_metric.m
@@ -19,7 +19,7 @@ for split = 1:cv_folds
 
     % Load data
     [xtr,xte,ytr,yte, BOW_xtr,BOW_xte, indices_tr, indices_te] = load_data(data_set, split);
-    [idx_tr, idx_val] = makesplits_seed(1, ytr, 0.8, 1, 1, 1);
+    [idx_tr, idx_val] = makesplits(ytr, 0.8, 1, 1);
     xv = xtr(idx_val);
     yv = ytr(idx_val);
     BOW_xv = BOW_xtr(idx_val);
@@ -34,7 +34,7 @@ for split = 1:cv_folds
 
 
     % First heuristically find a proper scale to avoid numeric problems
-    for ii = randperm(length(ytr),500)
+    for ii = randperm(length(idx_val),500)
         M = distance(A_SWCD*xtr{ii}, A_SWCD*xv{ii});
         dis_max(ii) = max(max(M));
     end


### PR DESCRIPTION
As discussed in https://github.com/gaohuang/S-WMD/issues/3, `scale_metric.m` uses `makesplits_seed` function, which is not available in the repository, to split data into training/test sets.  This PR replaces `makesplits_seed` with `makesplits` in the `/functions` directory.

This PR also addresses an issue where `randperm(length(ytr),500)` might sample an index out of range of `xv`.

@mkusner @gaohuang 